### PR TITLE
Fix install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
     'python-dateutil==2.7.5',
-    'enum34>1.1.0;python_version<"3.4"',
+    'enum34>1.1.0;python_version<"3.4"'
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':


### PR DESCRIPTION
error in luigi setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected ',' or end-of-list in enum34>1.1.0;python_version<"3.4" at ;python_version<"3.4"

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
